### PR TITLE
Fixed omniauth vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'devise'
 gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection', '~> 0.1'
 
 gem 'haml-rails', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -281,6 +284,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection (~> 0.1)
   pg (~> 1.1)
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.1)

--- a/app/views/users/shared/_links.html.haml
+++ b/app/views/users/shared/_links.html.haml
@@ -15,5 +15,5 @@
   %br/
 - if devise_mapping.omniauthable?
   - resource_class.omniauth_providers.each do |provider|
-    = link_to "Sign in with Google", user_google_oauth2_omniauth_authorize_path
+    = link_to "Sign in with Google", user_google_oauth2_omniauth_authorize_path, method: :post
     %br/

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -260,7 +260,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  OmniAuth.config.allowed_request_methods = [:post, :get]
+  OmniAuth.config.allowed_request_methods = [:post]
 
   if ENV['RAILS_MASTER_KEY'] || Rails.application.credentials.secret_key_base
     client_id = Rails.application.credentials[:google_omniauth][:client_id]

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -260,6 +260,8 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  OmniAuth.config.allowed_request_methods = [:post, :get]
+
   if ENV['RAILS_MASTER_KEY'] || Rails.application.credentials.secret_key_base
     client_id = Rails.application.credentials[:google_omniauth][:client_id]
     client_secret = Rails.application.credentials[:google_omniauth][:client_secret]

--- a/test/controllers/omniauth_csrf_test.rb
+++ b/test/controllers/omniauth_csrf_test.rb
@@ -4,7 +4,11 @@ require 'test_helper'
 class OmniauthCsrfTest < ActionDispatch::IntegrationTest
   setup do
     ActionController::Base.allow_forgery_protection = true
-    OmniAuth.config.test_mode = false
+  end
+
+  test 'should not accept GET requests to OmniAuth endpoint' do
+    get '/users/auth/google_oauth2'
+    assert_response :missing
   end
 
   test 'should not accept POST requests with invalid CSRF tokens to OmniAuth endpoint' do
@@ -15,6 +19,5 @@ class OmniauthCsrfTest < ActionDispatch::IntegrationTest
 
   teardown do
     ActionController::Base.allow_forgery_protection = false
-    OmniAuth.config.test_mode = true
   end
 end

--- a/test/controllers/omniauth_csrf_test.rb
+++ b/test/controllers/omniauth_csrf_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+# Make sure that https://nvd.nist.gov/vuln/detail/CVE-2015-9284 is mitigated
+class OmniauthCsrfTest < ActionDispatch::IntegrationTest
+  setup do
+    ActionController::Base.allow_forgery_protection = true
+    OmniAuth.config.test_mode = false
+  end
+
+  test 'should not accept POST requests with invalid CSRF tokens to OmniAuth endpoint' do
+    assert_raises ActionController::InvalidAuthenticityToken do
+      post '/users/auth/google_oauth2'
+    end
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = false
+    OmniAuth.config.test_mode = true
+  end
+end


### PR DESCRIPTION
Fixed Github warning:

> CVE-2015-9284

> Vulnerable versions: <= 1.9.0
Patched version: No fix
The request phase of the OmniAuth Ruby gem is vulnerable to Cross-Site Request Forgery when used as part of the Ruby on Rails framework, allowing accounts to be connected without user intent, user interaction, or feedback to the user. This permits a secondary account to be able to sign into the web application as the primary account.

Solution taken from [here.](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284)

> A key part of resolving this vulnerability is to avoid allowing GET requests for /auth/:provider.

> If using GET links to /auth/:provider is essential for your application (for example, if you are ever redirecting to /auth/:provider as part of an authentication process), then you will need to put together a more involved solution for your specific needs. 

I tried to solve this issue as suggested : 
in `app/views/users/shared/_links.html.haml`

```
- if devise_mapping.omniauthable?
  - resource_class.omniauth_providers.each do |provider|
    = link_to "Sign in with Google", '/users/auth/google_omniauth2', method: :post
```
But as well as app itself works, this test is failing with Error: `Expected response to be a <404: missing>, but was a <302: Found> redirect to <https://accounts.google.com/o/oauth2/auth?a...>`:

```
test "should not accept GET requests to OmniAuth endpoint" do
    get '/users/auth/google_oauth2'
    assert_response :missing
  end
```

Which means that our app still uses GET requests for redirecting to Google Omniauth and I need to allow them.
