### PR TITLE
Changed stylesheet_link_tag to stylesheet_pack_tag

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     %title BookSwap
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   %body.p-5
     = render 'layouts/alerts'


### PR DESCRIPTION
Now bootstrap is loaded in staging/production as well: that's why actually we need to change `stylesheet_link_tag` to `stylesheet_pack_tag`.