### PR TITLE
Added strip whitespaces method on user input in books controller

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,5 +1,7 @@
 class Book < ApplicationRecord
   belongs_to :user
+  before_validation :strip_input_fields
+
   validates :isbn10, length: { is: 10 },
                      numericality: { only_integer: true, greater_than: 0 },
                      allow_blank: true
@@ -7,4 +9,11 @@ class Book < ApplicationRecord
                      numericality: { only_integer: true, greater_than: 0 },
                      allow_blank: true
   validates :title, :author, :status, presence: true
+
+  private
+
+  def strip_input_fields
+    self.isbn10 = isbn10.strip unless isbn10.nil?
+    self.isbn13 = isbn13.strip unless isbn13.nil?
+  end
 end

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -1,12 +1,28 @@
 require 'test_helper'
 
 class BookTest < ActiveSupport::TestCase
+  include Devise::Test::IntegrationHelpers
+
   test 'isbn10 and isbn13 should be a string of numbers' do
+    user = users(:schmidt)
+    sign_in user
+
     book = Book.new(title: 'Pippi Langstrumf', author: 'Atsrid Lindgren', release_date: '1994',
                     status: 'available', isbn10: '1234arbnsP', isbn13: 'hgTb$12345123')
 
     book.validate
     assert_includes book.errors.to_a, 'Isbn10 is not a number'
     assert_includes book.errors.to_a, 'Isbn13 is not a number'
+  end
+
+  test 'remove trailing whitespaces in isbn10 and isbn13 fields' do
+    user = users(:schmidt)
+    sign_in user
+
+    book = Book.create(title: 'Pippi Langstrumf', author: 'Atsrid Lindgren', release_date: '1994',
+                       status: 'available', isbn10: '1546890654 ', isbn13: ' 9078612345123')
+
+    assert_equal '1546890654', book.isbn10
+    assert_equal '9078612345123', book.isbn13
   end
 end


### PR DESCRIPTION
I added method to remove trailing whitespaces from user input.  I had to do it in `BooksController` because for some reason validation happens earlier than `before_validation`.

But I left `def strip_input_fields` and test for it - simply commented it out (maybe you'll have an idea why it doesn't work properly).